### PR TITLE
feat: log deployment status while waiting for it to complete, use exponential delays

### DIFF
--- a/src/main/kotlin/nmcp/internal/task/publish.kt
+++ b/src/main/kotlin/nmcp/internal/task/publish.kt
@@ -76,6 +76,7 @@ fun publish(
     logger.lifecycle("Nmcp: deployment bundle '$deploymentId' uploaded to '$baseUrl'.")
 
     val timeout = verificationTimeoutSeconds?.seconds ?: 10.minutes
+    var delay = 2.seconds
     if (timeout.isPositive()) {
         logger.lifecycle("Nmcp: verifying deployment status...")
         val mark = markNow()
@@ -91,8 +92,12 @@ fun publish(
                 PENDING,
                 VALIDATING,
                 PUBLISHING -> {
-                    // Come back later
-                    Thread.sleep(2000)
+                    logger.lifecycle("Deployment status is '$status', will try again in ${delay.inWholeSeconds}s.")
+                    // Wait for the next attempt to reduce the load on the Central Portal API
+                    Thread.sleep(delay.inWholeMilliseconds)
+                    // Increase the delay exponentially, so we don't send too frequent requests if the deployment takes time
+                    delay = (delay * 2).coerceAtMost(64.seconds)
+                    continue
                 }
 
                 VALIDATED -> {


### PR DESCRIPTION
Fixes https://github.com/GradleUp/nmcp/issues/53