### PR TITLE
feat: move centralPortal {...} to publishing {...}

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@ plugins {
 }
 
 nmcpAggregation {
-    centralPortal {
-        username = TODO("Create a token username at https://central.sonatype.com/account") 
-        password = TODO("Create a token password at https://central.sonatype.com/account")
-        // publish manually from the portal
-        publishingType = "USER_MANAGED"
-        // or if you want to publish automatically
-        publishingType = "AUTOMATIC"
-    }
- 
     // Publish all projects that apply the 'maven-publish' plugin
     publishAllProjectsProbablyBreakingProjectIsolation()
+}
+
+publishing {
+  centralPortal {
+    username = TODO("Create a token username at https://central.sonatype.com/account")
+    password = TODO("Create a token password at https://central.sonatype.com/account")
+    // publish manually from the portal
+    publishingType = "USER_MANAGED"
+    // or if you want to publish automatically
+    publishingType = "AUTOMATIC"
+  }
 }
 ```
 
@@ -65,7 +67,7 @@ plugins {
     id("com.gradleup.nmcp.aggregation").version("0.1.1")
 }
 
-nmcpAggregation {
+publishing {
     centralPortal {
         username = TODO("Create a token username at https://central.sonatype.com/account") 
         password = TODO("Create a token password at https://central.sonatype.com/account")
@@ -98,7 +100,7 @@ plugins {
 
 // Create your publications
 
-nmcp {
+publishing {
     centralPortal {
         username = TODO("Create a token username at https://central.sonatype.com/account") 
         password = TODO("Create a token password at https://central.sonatype.com/account")

--- a/src/main/kotlin/nmcp/NmcpAggregationExtension.kt
+++ b/src/main/kotlin/nmcp/NmcpAggregationExtension.kt
@@ -8,11 +8,13 @@ import nmcp.internal.task.registerPublishTask
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.bundling.Zip
 
 @GExtension(pluginId = "com.gradleup.nmcp.aggregation")
 abstract class NmcpAggregationExtension(private val project: Project) {
-    internal val spec = project.objects.newInstance(CentralPortalOptions::class.java)
+    private val spec: CentralPortalOptions
 
     @get:Inject
     abstract val archiveOperations: ArchiveOperations
@@ -25,6 +27,10 @@ abstract class NmcpAggregationExtension(private val project: Project) {
     }
 
     init {
+        project.pluginManager.apply("com.gradleup.nmcp.central-portal-options")
+        spec = (project.extensions.getByType(PublishingExtension::class.java) as ExtensionAware)
+            .extensions.getByType(CentralPortalOptions::class.java)
+
         val operations = archiveOperations
         val layout = project.layout
         val files = project.files(consumerConfiguration)

--- a/src/main/kotlin/nmcp/NmcpExtension.kt
+++ b/src/main/kotlin/nmcp/NmcpExtension.kt
@@ -8,16 +8,21 @@ import nmcp.internal.task.registerPublishTask
 import nmcp.internal.withRequiredPlugin
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.bundling.Zip
 
 @GExtension(pluginId = "com.gradleup.nmcp")
 open class NmcpExtension(private val project: Project) {
-    internal val spec = project.objects.newInstance(CentralPortalOptions::class.java)
+    private val spec: CentralPortalOptions
     // Lifecycle task to publish all the publications in the given project
     private val publishAllPublicationsToCentralPortal = project.tasks.register("publishAllPublicationsToCentralPortal")
 
     init {
+        project.pluginManager.apply("com.gradleup.nmcp.central-portal-options")
+        spec = (project.extensions.getByType(PublishingExtension::class.java) as ExtensionAware)
+            .extensions.getByType(CentralPortalOptions::class.java)
+
         project.configurations.create(nmcpProducerConfigurationName) {
             it.isCanBeConsumed = true
             it.isCanBeResolved = false

--- a/src/main/kotlin/nmcp/internal/plugins.kt
+++ b/src/main/kotlin/nmcp/internal/plugins.kt
@@ -1,0 +1,14 @@
+package nmcp.internal
+
+import gratatouille.GPlugin
+import nmcp.CentralPortalOptions
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.publish.PublishingExtension
+
+@GPlugin("com.gradleup.nmcp.central-portal-options")
+fun centralPortalOptions(target: Project) {
+    target.pluginManager.apply("publishing")
+    val publishing = target.extensions.getByType(PublishingExtension::class.java)
+    (publishing as ExtensionAware).extensions.create("centralPortal", CentralPortalOptions::class.java)
+}

--- a/tests/kmp/build.gradle.kts
+++ b/tests/kmp/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     add("nmcpAggregation", project(":module2"))
 }
 
-extensions.getByType(nmcp.NmcpAggregationExtension::class.java).apply {
-    centralPortal {
+extensions.getByType(PublishingExtension::class.java).apply {
+    (this as ExtensionAware).extensions.getByType(nmcp.CentralPortalOptions::class.java).apply {
         if (System.getenv("MAVEN_CENTRAL_USERNAME") == null) {
             username = "placeholder"
             password = "placeholedr"


### PR DESCRIPTION
It sounds reasonable to have Central Portal settings under `publishing {..}`
It sounds reasonable to have the same configuration API for both aggregating and non-aggregating nmcp.