### PR TITLE
Compatibility with Kotlin 1.9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ version = "0.1.5"
 
 compatPatrouille {
     java(17)
-    kotlin("2.0.0")
+    kotlin("1.9.0")
 }
 
 publishing {


### PR DESCRIPTION
Not going to 1.8 because of 

```
> Task :compileKotlin
e: file:///Users/martinbonnin/git/nmcp/build/generated/ksp/main/kotlin/nmcp/internal/task/PublishReleaseTask.kt:198:24 This declaration needs opt-in. Its usage must be marked with '@kotlin.ExperimentalStdlibApi' or '@OptIn(kotlin.ExperimentalStdlibApi::class)'
e: file:///Users/martinbonnin/git/nmcp/build/generated/ksp/main/kotlin/nmcp/internal/task/PublishReleaseTask.kt:198:33 This declaration needs opt-in. Its usage must be marked with '@kotlin.ExperimentalStdlibApi' or '@OptIn(kotlin.ExperimentalStdlibApi::class)'
e: file:///Users/martinbonnin/git/nmcp/build/generated/ksp/main/kotlin/nmcp/internal/task/PublishReleaseTask.kt:198:33 The feature "enum entries" is only available since language version 1.9
e: file:///Users/martinbonnin/git/nmcp/build/generated/ksp/main/kotlin/nmcp/internal/task/PublishSnapshotTask.kt:161:24 This declaration needs opt-in. Its usage must be marked with '@kotlin.ExperimentalStdlibApi' or '@OptIn(kotlin.ExperimentalStdlibApi::class)'
e: file:///Users/martinbonnin/git/nmcp/build/generated/ksp/main/kotlin/nmcp/internal/task/PublishSnapshotTask.kt:161:33 This declaration needs opt-in. Its usage must be marked with '@kotlin.ExperimentalStdlibApi' or '@OptIn(kotlin.ExperimentalStdlibApi::class)'
e: file:///Users/martinbonnin/git/nmcp/build/generated/ksp/main/kotlin/nmcp/internal/task/PublishSnapshotTask.kt:161:33 The feature "enum entries" is only available since language version 1.9
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:113:16 This declaration needs opt-in. Its usage must be marked with '@kotlin.time.ExperimentalTime' or '@OptIn(kotlin.time.ExperimentalTime::class)'
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:115:15 This declaration needs opt-in. Its usage must be marked with '@kotlin.time.ExperimentalTime' or '@OptIn(kotlin.time.ExperimentalTime::class)'
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:115:20 This declaration needs opt-in. Its usage must be marked with '@kotlin.time.ExperimentalTime' or '@OptIn(kotlin.time.ExperimentalTime::class)'
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:129:135 This declaration needs opt-in. Its usage must be marked with '@kotlin.time.ExperimentalTime' or '@OptIn(kotlin.time.ExperimentalTime::class)'
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:129:140 This declaration needs opt-in. Its usage must be marked with '@kotlin.time.ExperimentalTime' or '@OptIn(kotlin.time.ExperimentalTime::class)'
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:140:9 The feature "data objects" is only available since language version 1.9
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:143:9 The feature "data objects" is only available since language version 1.9
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:146:9 The feature "data objects" is only available since language version 1.9
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:149:9 The feature "data objects" is only available since language version 1.9
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:152:9 The feature "data objects" is only available since language version 1.9
e: file:///Users/martinbonnin/git/nmcp/src/main/kotlin/nmcp/internal/task/publishRelease.kt:155:9 The feature "data objects" is only available since language version 1.9
```