### PR TITLE
Use "Authentication: Bearer" instead of "Authentication: UserToken"

### DIFF
--- a/src/main/kotlin/nmcp/internal/task/nmcpPublishWithPublisherApi.kt
+++ b/src/main/kotlin/nmcp/internal/task/nmcpPublishWithPublisherApi.kt
@@ -63,7 +63,7 @@ fun nmcpPublishWithPublisherApi(
     logger.lifecycle("Uploading deployment to '$url'")
     val deploymentId = Request.Builder()
         .post(body)
-        .addHeader("Authorization", "UserToken $token")
+        .addHeader("Authorization", "Bearer $token")
         .url(url)
         .build()
         .let {


### PR DESCRIPTION
See https://central.sonatype.org/publish/publish-portal-api/
