### PR TITLE
Publish all projects (including root), and not only subprojects

### DIFF
--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpAggregationExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpAggregationExtension.kt
@@ -29,7 +29,7 @@ abstract class DefaultNmcpAggregationExtension(private val project: Project) : N
             "publishAllProjectsProbablyBreakingProjectIsolation() must be called from root project"
         }
 
-        project.subprojects { aproject ->
+        project.allprojects { aproject ->
             aproject.pluginManager.withPlugin("maven-publish") {
                 aproject.pluginManager.apply("com.gradleup.nmcp")
 


### PR DESCRIPTION
This is only for projects that apply `maven-publish` so if the the root project doesn't apply it, this is a no-op