### PR TITLE
Remove duplicate plugin markers

### DIFF
--- a/nmcp/build.gradle.kts
+++ b/nmcp/build.gradle.kts
@@ -20,8 +20,6 @@ gratatouille {
     codeGeneration {
         addDependencies.set(false)
     }
-    pluginMarker("com.gradleup.nmcp", "default")
-    pluginMarker("com.gradleup.nmcp.aggregation", "default")
 }
 
 dependencies {


### PR DESCRIPTION
Librarian now publishes the markers automagically 🎉 