### PR TITLE
Expand the zip files when passing it to `allFiles`

### DIFF
--- a/nmcp/src/main/kotlin/nmcp/NmcpAggregationExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/NmcpAggregationExtension.kt
@@ -23,6 +23,8 @@ interface NmcpAggregationExtension {
 
     /**
      * [allFiles] contains all the files present in the "nmcpAggregation" configuration
+     *
+     * This [FileCollection] is a multi-rooted [org.gradle.api.file.FileTree] containing only files
      */
     val allFiles: FileCollection
 }

--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpAggregationExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpAggregationExtension.kt
@@ -4,6 +4,7 @@ import nmcp.CentralPortalOptions
 import nmcp.NmcpAggregationExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 
 internal abstract class DefaultNmcpAggregationExtension(private val project: Project) : NmcpAggregationExtension {
     private var centralPortalConfigured = false
@@ -15,7 +16,7 @@ internal abstract class DefaultNmcpAggregationExtension(private val project: Pro
         it.configureAttributes(project)
     }
 
-    override val allFiles = consumerConfiguration.incoming.artifactView { it.lenient(true) }.files
+    override val allFiles: FileCollection = consumerConfiguration.incoming.artifactView { it.lenient(true) }.files.asFileTree
 
     override fun centralPortal(action: Action<CentralPortalOptions>) {
         check(!centralPortalConfigured) {


### PR DESCRIPTION
I think it's clearer to have a `FileCollection` that only contains `File`s and not directories.