### PR TITLE
Enable typesafe accessors

### DIFF
--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpAggregationExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpAggregationExtension.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 
 internal abstract class DefaultNmcpAggregationExtension(private val project: Project) : NmcpAggregationExtension {
-    private var centralPortalConfigured = false
+    private val spec = project.objects.newInstance(CentralPortalOptions::class.java)
 
     internal val consumerConfiguration = project.configurations.create(nmcpConsumerConfigurationName) {
         it.isCanBeResolved = true
@@ -17,17 +17,16 @@ internal abstract class DefaultNmcpAggregationExtension(private val project: Pro
 
     override val allFiles = consumerConfiguration.incoming.artifactView { it.lenient(true) }.files
 
-    override fun centralPortal(action: Action<CentralPortalOptions>) {
-        check(!centralPortalConfigured) {
-            "Nmcp: centralPortal {} must be called only once"
-        }
-        centralPortalConfigured = true
+    init {
 
         project.registerPublishToCentralPortalTasks(
             kind = Kind.aggregation,
             inputFiles = allFiles,
-            action = action
+            spec = spec
         )
+    }
+    override fun centralPortal(action: Action<CentralPortalOptions>) {
+        action.execute(spec)
     }
 
     override fun publishAllProjectsProbablyBreakingProjectIsolation() {

--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
@@ -12,6 +12,7 @@ import org.gradle.api.publish.maven.MavenPublication
 internal abstract class DefaultNmcpExtension(private val project: Project): NmcpExtension {
     private var centralPortalConfigured = false
     private val m2Dir = project.layout.buildDirectory.file("nmcp/m2")
+    private val spec = project.objects.newInstance(CentralPortalOptions::class.java)
 
     // TODO: it's not clear whether we need that while we could simply resolve the project artifacts
     private val m2Files = project.files()
@@ -68,20 +69,16 @@ internal abstract class DefaultNmcpExtension(private val project: Project): Nmcp
                     }
                 }
             }
+            project.registerPublishToCentralPortalTasks(
+                kind = Kind.allPublications,
+                inputFiles = m2Files,
+                spec = spec
+            )
         }
     }
 
     override fun publishAllPublicationsToCentralPortal(action: Action<CentralPortalOptions>) {
-        check(!centralPortalConfigured) {
-            "Nmcp: centralPortal {} must be called only once"
-        }
-        centralPortalConfigured = true
-
-        project.registerPublishToCentralPortalTasks(
-            kind = Kind.allPublications,
-            inputFiles = m2Files,
-            action = action
-        )
+        action.execute(spec)
     }
 
     override fun extraFiles(files: Any) {

--- a/nmcp/src/main/kotlin/nmcp/internal/utils.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/utils.kt
@@ -59,11 +59,9 @@ internal enum class Kind {
 internal fun Project.registerPublishToCentralPortalTasks(
     kind: Kind,
     inputFiles: FileCollection,
-    action: Action<CentralPortalOptions>,
+    spec: CentralPortalOptions,
 ) {
     val name = kind.name
-    val spec = objects.newInstance(CentralPortalOptions::class.java)
-    action.execute(spec)
 
     val releaseTaskName = "nmcpPublish${name.capitalizeFirstLetter()}ToCentralPortal"
     val snapshotTaskName = "nmcpPublish${name.capitalizeFirstLetter()}ToCentralPortalSnapshots"


### PR DESCRIPTION
Register tasks eagerly. Closes https://github.com/GradleUp/nmcp/issues/217

