### PR TITLE
Deprecate `publishAllPublicationsToCentralPortal()`

### DIFF
--- a/nmcp/src/main/kotlin/nmcp/NmcpExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/NmcpExtension.kt
@@ -11,6 +11,7 @@ interface NmcpExtension {
      * - Adds `nmcpPublishAllPublicationsToCentralPortal`
      * - Adds `nmcpPublishAllPublicationsToCentralPortalSnapshots`
      */
+    @Deprecated("This duplicates the com.gradleup.nmcp.aggregation functionality. Either apply com.gradleup.nmcp.aggregation or the settings plugin to publish an aggregation.")
     fun publishAllPublicationsToCentralPortal(action: Action<CentralPortalOptions>)
 
     /**

--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
@@ -83,6 +83,7 @@ internal abstract class DefaultNmcpExtension(private val project: Project): Nmcp
         }
     }
 
+    @Deprecated("This duplicates the com.gradleup.nmcp.aggregation functionality. Either apply com.gradleup.nmcp.aggregation or the settings plugin to publish an aggregation.")
     override fun publishAllPublicationsToCentralPortal(action: Action<CentralPortalOptions>) {
         action.execute(spec)
     }


### PR DESCRIPTION
The same functionality can be acheived using the aggregation:

```kotlin
plugins {
  id("com.gradleup.nmcp") // for exposing all the publications
  id("com.gradleup.nmcp.aggregation") // for configuring the aggregation
}

nmcpAggregation {
  centralPortal {
    username.set("")
    password.get("")
    publishAllChecksums.set(true)
  }
}

dependencies {
  nmcpAggregation(project)
}
```

This makes for a clearer separation of concerns and will make the plugin maintainance easier moving forward.