### PR TITLE
Fix Gradle 10 issue in `DefaultNmcpSettings`

### DIFF
--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpSettings.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpSettings.kt
@@ -34,7 +34,8 @@ abstract class DefaultNmcpSettings(settings: Settings): NmcpSettings {
                 }
 
                 project.allprojects {
-                    project.dependencies.add(nmcpConsumerConfigurationName, project.dependencies.create(it))
+                    project.dependencies.add(nmcpConsumerConfigurationName,
+                        project.dependencies.project(mapOf("path" to it.path)))
                 }
             }
             project.pluginManager.withPlugin("maven-publish") {


### PR DESCRIPTION
Fix the Gradle 10 deprecation warning in `DefaultNmcpSettings` by using `DependencyHandler.project()` instead of `DependencyHandler.create()`.

Using the other recommended way via `DependencyFactory.createProjectDependency()` isn't available in NMCP's min Gradle-API version 8.8.

Warning message and location:
```
Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10. Please use the project(String) method on DependencyHandler or the createProjectDependency(String) method on DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.6.1/userguide/upgrading_version_9.html#dependency_project_notation

        at nmcp.internal.DefaultNmcpSettings.lambda$0$1(DefaultNmcpSettings.kt:37)
        at nmcp.internal.DefaultNmcpSettings.lambda$0$2(DefaultNmcpSettings.kt:36)
```