### PR TITLE
Remove deprecated Configuration.setVisible(boolean) call (Gradle 9.8)

### DIFF
--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
@@ -24,8 +24,6 @@ internal abstract class DefaultNmcpExtension(private val project: Project): Nmcp
         project.configurations.create(nmcpProducerConfigurationName) {
             it.isCanBeConsumed = true
             it.isCanBeResolved = false
-            // See https://github.com/GradleUp/nmcp/issues/2
-            it.isVisible = false
 
             it.configureAttributes(project)
         }

--- a/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
+++ b/nmcp/src/main/kotlin/nmcp/internal/DefaultNmcpExtension.kt
@@ -10,6 +10,7 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.util.GradleVersion
 
 @GExtension(pluginId = "com.gradleup.nmcp", publicType = NmcpExtension::class, extensionName = nmcpExtensionName)
 internal abstract class DefaultNmcpExtension(private val project: Project): NmcpExtension {
@@ -24,6 +25,13 @@ internal abstract class DefaultNmcpExtension(private val project: Project): Nmcp
         project.configurations.create(nmcpProducerConfigurationName) {
             it.isCanBeConsumed = true
             it.isCanBeResolved = false
+            // See https://github.com/GradleUp/nmcp/issues/2
+            // Without this, the publications end up being published as part of `assemble`.
+            // `Configuration.setVisible(boolean)` is deprecated as of Gradle 9.8 (and inert since),
+            // so only call it on older Gradle versions to stay warning-clean on 9.8+.
+            if (GradleVersion.current() < GradleVersion.version("9.8")) {
+                it.isVisible = false
+            }
 
             it.configureAttributes(project)
         }


### PR DESCRIPTION
## Problem

The per-project nmcp plugin creates its **producer** configuration and calls `isVisible = false` on it. As of **Gradle 9.8.0-milestone-2**, `Configuration.setVisible(boolean)` is deprecated (scheduled for removal in Gradle 11):

```
The Configuration.setVisible(boolean) method has been deprecated. This is
scheduled to be removed in Gradle 11.
	at nmcp.internal.DefaultNmcpExtension...  <-- offending call
```

Any build that treats deprecation warnings as errors (`org.gradle.warning.mode=fail`) fails as soon as a project applying the nmcp plugin is configured. This is present in **every published version (0.1.5 … 1.6.1) and on `main`**, so consumers have no upgrade path around it. The elasticsearch team is affected by that.

Surfaced downstream in Elasticsearch CI while bumping the Gradle wrapper to 9.8.0-milestone-2 — the build fails while configuring a subproject that applies the nmcp `elasticsearch.publish` convention plugin, because `gradle.properties` sets `systemProp.org.gradle.warning.mode=fail`.

## Fix

Remove the `it.isVisible = false` line.

- Gradle deprecated the `visible` property because it "no longer has any meaningful effect on the build" (Gradle 9.8 upgrade guide, `#deprecate-visible-property`). Dropping the call changes no runtime behaviour on any supported Gradle version.
- The original reason for the line (referencing GradleUp/nmcp#2) — keeping the internal `nmcpProducer` configuration out of certain reports — is now handled by the `canBeConsumed=true` / `canBeResolved=false` role flags, not by `visible`.

Only the producer configuration set `visible`; the aggregation/consumer configuration is unaffected.

## Reproduce

```
./gradlew <someProject>:help --warning-mode=all --stacktrace
```
with a project applying the nmcp per-project plugin under Gradle 9.8.0-milestone-2.
